### PR TITLE
Generalize for business cockpit

### DIFF
--- a/.github/workflows/deploy-to-github-packages.yaml
+++ b/.github/workflows/deploy-to-github-packages.yaml
@@ -1,0 +1,22 @@
+name: Publish to GitHub Packages
+on: push
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          cache: 'maven'
+      - name: Publish package
+        run: mvn -s $GITHUB_WORKSPACE/.github/workflows/github-packages-settings.xml --batch-mode deploy
+        env:
+          USER_NAME: ${{ secrets.VANILLABP_USER_NAME }}
+          USER_TOKEN: ${{ secrets.VANILLABP_USER_TOKEN }}
+          CAMUNDA_USER_TOKEN: ${{ secrets.CAMUNDA_USER_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/github-packages-settings.xml
+++ b/.github/workflows/github-packages-settings.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+    <activeProfiles>
+        <activeProfile>github</activeProfile>
+    </activeProfiles>
+    <profiles>
+        <profile>
+            <id>github</id>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <url>https://repo1.maven.org/maven2</url>
+                </repository>
+                <repository>
+                    <id>vanillabp-spring-boot-support</id>
+                    <url>https://maven.pkg.github.com/vanillabp/spring-boot-support</url>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                    <releases>
+                        <enabled>true</enabled>
+                  </releases>
+                </repository>
+            </repositories>
+        </profile>
+    </profiles>
+
+    <servers>
+        <server>
+            <id>vanillabp-spring-boot-support</id>
+            <username>${env.USER_NAME}</username>
+            <password>${env.USER_TOKEN}</password>
+        </server>
+        <server>
+            <id>github</id>
+            <username>${env.USER_NAME}</username>
+            <password>${env.CAMUNDA_USER_TOKEN}</password>
+        </server>
+    </servers>
+
+</settings>
+

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,13 @@
             <release>${version.java}</release>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <configuration>
+            <skip>false</skip>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>
@@ -60,4 +67,12 @@
     <developerConnection>scm:git:https://github.com/camunda-community-hub/vanillabp-camunda8-adapter.git</developerConnection>
     <url>http://github.com/camunda-community-hub/vanillabp-camunda8-adapter/tree/main</url>
   </scm>
+
+  <distributionManagement>
+    <snapshotRepository>
+      <id>github</id>
+      <name>Github Packages</name>
+      <url>https://maven.pkg.github.com/camunda-community-hub/vanillabp-camunda8-adapter</url>
+    </snapshotRepository>
+  </distributionManagement>
 </project>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>io.vanillabp</groupId>
       <artifactId>spring-boot-support</artifactId>
-      <version>1.0.5-SNAPSHOT</version>
+      <version>1.0.5</version>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -35,7 +35,7 @@
     <dependency>
       <groupId>io.vanillabp</groupId>
       <artifactId>spring-boot-support</artifactId>
-      <version>1.0.4</version>
+      <version>1.0.5-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/Camunda8TaskWiring.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/Camunda8TaskWiring.java
@@ -33,7 +33,7 @@ import io.vanillabp.springboot.adapter.SpringDataUtil;
 import io.vanillabp.springboot.adapter.TaskWiringBase;
 import io.vanillabp.springboot.parameters.MethodParameter;
 
-public class Camunda8TaskWiring extends TaskWiringBase<Camunda8Connectable, Camunda8ProcessService<?>>
+public class Camunda8TaskWiring extends TaskWiringBase<Camunda8Connectable, Camunda8ProcessService<?>, Camunda8MethodParameterFactory>
         implements Consumer<ZeebeClient> {
 
     private final String workerId;

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MethodParameterFactory.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MethodParameterFactory.java
@@ -12,10 +12,12 @@ public class Camunda8MethodParameterFactory extends MethodParameterFactory {
 
     @Override
     public ResolverBasedMultiInstanceMethodParameter getResolverBasedMultiInstanceMethodParameter(
+            final int index,
             final String parameter,
             final MultiInstanceElementResolver<?, ?> resolverBean) {
 
         return new Camunda8ResolverBasedMethodParameter(
+                index,
                 parameter,
                 resolverBean);
 
@@ -23,10 +25,12 @@ public class Camunda8MethodParameterFactory extends MethodParameterFactory {
 
     @Override
     public MultiInstanceElementMethodParameter getMultiInstanceElementMethodParameter(
+            final int index,
             final String parameter,
             final String name) {
 
         return new Camunda8MultiInstanceElementMethodParameter(
+                index,
                 parameter,
                 name);
 
@@ -34,10 +38,12 @@ public class Camunda8MethodParameterFactory extends MethodParameterFactory {
 
     @Override
     public MultiInstanceIndexMethodParameter getMultiInstanceIndexMethodParameter(
+            final int index,
             final String parameter,
             final String name) {
 
         return new Camunda8MultiInstanceIndexMethodParameter(
+                index,
                 parameter,
                 name);
 
@@ -45,10 +51,12 @@ public class Camunda8MethodParameterFactory extends MethodParameterFactory {
 
     @Override
     public MultiInstanceTotalMethodParameter getMultiInstanceTotalMethodParameter(
+            final int index,
             final String parameter,
             final String name) {
 
         return new Camunda8MultiInstanceTotalMethodParameter(
+                index,
                 parameter,
                 name);
 
@@ -56,10 +64,12 @@ public class Camunda8MethodParameterFactory extends MethodParameterFactory {
     
     @Override
     public TaskParameter getTaskParameter(
+            final int index,
             final String parameter,
             final String name) {
         
         return new Camunda8TaskParameter(
+                index,
                 parameter,
                 name);
         

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MethodParameterFactory.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MethodParameterFactory.java
@@ -12,41 +12,56 @@ public class Camunda8MethodParameterFactory extends MethodParameterFactory {
 
     @Override
     public ResolverBasedMultiInstanceMethodParameter getResolverBasedMultiInstanceMethodParameter(
+            final String parameter,
             final MultiInstanceElementResolver<?, ?> resolverBean) {
 
-        return new Camunda8ResolverBasedMethodParameter(resolverBean);
+        return new Camunda8ResolverBasedMethodParameter(
+                parameter,
+                resolverBean);
 
     }
 
     @Override
     public MultiInstanceElementMethodParameter getMultiInstanceElementMethodParameter(
+            final String parameter,
             final String name) {
 
-        return new Camunda8MultiInstanceElementMethodParameter(name);
+        return new Camunda8MultiInstanceElementMethodParameter(
+                parameter,
+                name);
 
     }
 
     @Override
     public MultiInstanceIndexMethodParameter getMultiInstanceIndexMethodParameter(
+            final String parameter,
             final String name) {
 
-        return new Camunda8MultiInstanceIndexMethodParameter(name);
+        return new Camunda8MultiInstanceIndexMethodParameter(
+                parameter,
+                name);
 
     }
 
     @Override
     public MultiInstanceTotalMethodParameter getMultiInstanceTotalMethodParameter(
+            final String parameter,
             final String name) {
 
-        return new Camunda8MultiInstanceTotalMethodParameter(name);
+        return new Camunda8MultiInstanceTotalMethodParameter(
+                parameter,
+                name);
 
     }
     
     @Override
     public TaskParameter getTaskParameter(
+            final String parameter,
             final String name) {
         
-        return new Camunda8TaskParameter(name);
+        return new Camunda8TaskParameter(
+                parameter,
+                name);
         
     }
     

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceElementMethodParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceElementMethodParameter.java
@@ -8,9 +8,10 @@ public class Camunda8MultiInstanceElementMethodParameter extends MultiInstanceEl
         implements ParameterVariables {
 
     public Camunda8MultiInstanceElementMethodParameter(
+            final String parameter,
             final String name) {
         
-        super(name);
+        super(parameter, name);
         
     }
 

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceElementMethodParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceElementMethodParameter.java
@@ -8,10 +8,11 @@ public class Camunda8MultiInstanceElementMethodParameter extends MultiInstanceEl
         implements ParameterVariables {
 
     public Camunda8MultiInstanceElementMethodParameter(
+            final int index,
             final String parameter,
             final String name) {
         
-        super(parameter, name);
+        super(index, parameter, name);
         
     }
 

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceIndexMethodParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceIndexMethodParameter.java
@@ -10,10 +10,11 @@ public class Camunda8MultiInstanceIndexMethodParameter extends MultiInstanceInde
     public static final String SUFFIX = "_index";
 
     public Camunda8MultiInstanceIndexMethodParameter(
+            final int index,
             final String parameter,
             final String name) {
 
-        super(parameter, name);
+        super(index, parameter, name);
 
     }
 

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceIndexMethodParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceIndexMethodParameter.java
@@ -10,9 +10,10 @@ public class Camunda8MultiInstanceIndexMethodParameter extends MultiInstanceInde
     public static final String SUFFIX = "_index";
 
     public Camunda8MultiInstanceIndexMethodParameter(
+            final String parameter,
             final String name) {
 
-        super(name);
+        super(parameter, name);
 
     }
 

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceTotalMethodParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceTotalMethodParameter.java
@@ -10,9 +10,10 @@ public class Camunda8MultiInstanceTotalMethodParameter extends MultiInstanceTota
     public static final String SUFFIX = "_total";
 
     public Camunda8MultiInstanceTotalMethodParameter(
+            final String parameter,
             final String name) {
         
-        super(name);
+        super(parameter, name);
         
     }
 

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceTotalMethodParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8MultiInstanceTotalMethodParameter.java
@@ -10,10 +10,11 @@ public class Camunda8MultiInstanceTotalMethodParameter extends MultiInstanceTota
     public static final String SUFFIX = "_total";
 
     public Camunda8MultiInstanceTotalMethodParameter(
+            final int index,
             final String parameter,
             final String name) {
         
-        super(parameter, name);
+        super(index, parameter, name);
         
     }
 

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8ResolverBasedMethodParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8ResolverBasedMethodParameter.java
@@ -10,9 +10,10 @@ public class Camunda8ResolverBasedMethodParameter extends ResolverBasedMultiInst
         implements ParameterVariables {
 
     public Camunda8ResolverBasedMethodParameter(
+            final String parameter,
             final MultiInstanceElementResolver<?, ?> resolverBean) {
 
-        super(resolverBean);
+        super(parameter, resolverBean);
 
     }
     

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8ResolverBasedMethodParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8ResolverBasedMethodParameter.java
@@ -10,10 +10,11 @@ public class Camunda8ResolverBasedMethodParameter extends ResolverBasedMultiInst
         implements ParameterVariables {
 
     public Camunda8ResolverBasedMethodParameter(
+            final int index,
             final String parameter,
             final MultiInstanceElementResolver<?, ?> resolverBean) {
 
-        super(parameter, resolverBean);
+        super(index, parameter, resolverBean);
 
     }
     

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8TaskParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8TaskParameter.java
@@ -7,9 +7,10 @@ import java.util.List;
 public class Camunda8TaskParameter extends TaskParameter implements ParameterVariables {
 
     public Camunda8TaskParameter(
+            final String parameter,
             final String name) {
         
-        super(name);
+        super(parameter, name);
 
     }
     

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8TaskParameter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/parameters/Camunda8TaskParameter.java
@@ -7,10 +7,11 @@ import java.util.List;
 public class Camunda8TaskParameter extends TaskParameter implements ParameterVariables {
 
     public Camunda8TaskParameter(
+            final int index,
             final String parameter,
             final String name) {
         
-        super(parameter, name);
+        super(index, parameter, name);
 
     }
     


### PR DESCRIPTION
Also VanillaBP business cockpit uses annotations as code-wiring. The reuse the mechanism already available in VanillaBP a refactoring is necessary.