### PR TITLE
Fix missing workflow module id in persistence

### DIFF
--- a/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/Camunda8DeploymentAdapter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/Camunda8DeploymentAdapter.java
@@ -171,6 +171,7 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
             deployedResources
                     .getProcesses()
                     .forEach(process -> deploymentService.addProcess(
+                            workflowModuleId,
                             deploymentHashCode[0],
                             process,
                             deployedProcesses.get(process.getBpmnProcessId())));
@@ -179,7 +180,7 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
         
         // BPMNs which were deployed in the past need to be forced to be parsed for wiring
         deploymentService
-                .getBpmnNotOfPackage(deploymentHashCode[0])
+                .getBpmnNotOfPackage(workflowModuleId, deploymentHashCode[0])
                 .forEach(bpmn -> {
                     
                     try (var inputStream = new ByteArrayInputStream(

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/Deployment.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/Deployment.java
@@ -8,6 +8,8 @@ public interface Deployment {
 
     int getVersion();
 
+    String getWorkflowModuleId();
+
     int getPackageId();
 
     OffsetDateTime getPublishedAt();

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/DeploymentPersistence.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/DeploymentPersistence.java
@@ -9,10 +9,15 @@ public interface DeploymentPersistence {
     Optional<? extends Deployment> findDeployedProcess(
             long definitionKey);
 
+    <R extends DeployedProcess> R updateMissingWorkflowModuleIdOfDeployedProcess(
+            R deployedProcess,
+            String workflowModuleId);
+
     <R extends DeployedProcess> R addDeployedProcess(
             long definitionKey,
             int version,
             int packageId,
+            String workflowModuleId,
             String bpmnProcessId,
             final DeployedBpmn bpmn,
             OffsetDateTime publishedAt);
@@ -26,6 +31,7 @@ public interface DeploymentPersistence {
             byte[] resource);
 
     List<? extends DeployedBpmn> getBpmnNotOfPackage(
-            final int packageId);
+            String workflowModuleId,
+            int packageId);
 
 }

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/DeploymentService.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/DeploymentService.java
@@ -91,6 +91,7 @@ public class DeploymentService {
             maxAttempts = 100,
             backoff = @Backoff(delay = 200, maxDelay = 1000, multiplier = 1.5, random = true))
     public DeployedProcess addProcess(
+            final String workflowModuleId,
             final int packageId,
             final Process camunda8DeployedProcess,
             final DeployedBpmn bpmn) {
@@ -100,13 +101,18 @@ public class DeploymentService {
         final var previous = persistence.findDeployedProcess(versionedId);
         if (previous.isPresent()
                 && (previous.get().getVersion() == camunda8DeployedProcess.getVersion())) {
-            return (DeployedProcess) previous.get();
+            var result = (DeployedProcess) previous.get();
+            if (result.getWorkflowModuleId() == null) {
+                result = persistence.updateMissingWorkflowModuleIdOfDeployedProcess(result, workflowModuleId);
+            }
+            return result;
         }
 
         return persistence.addDeployedProcess(
                 versionedId,
                 camunda8DeployedProcess.getVersion(),
                 packageId,
+                workflowModuleId,
                 camunda8DeployedProcess.getBpmnProcessId(),
                 bpmn,
                 OffsetDateTime.now());
@@ -116,27 +122,30 @@ public class DeploymentService {
     @Recover
     public DeployedProcess recoverAddProcess(
             final OptimisticLockingFailureException exception,
+            final String workflowModuleId,
             final int packageId,
             final Process camunda8DeployedProcess,
             final DeployedBpmn bpmn) {
 
-        return staleRecoverAddProcess(exception, packageId, camunda8DeployedProcess, bpmn);
+        return staleRecoverAddProcess(exception, workflowModuleId, packageId, camunda8DeployedProcess, bpmn);
 
     }
 
     @Recover
     public DeployedProcess recoverAddProcess(
             final ObjectOptimisticLockingFailureException exception,
+            final String workflowModuleId,
             final int packageId,
             final Process camunda8DeployedProcess,
             final DeployedBpmn bpmn) {
 
-        return staleRecoverAddProcess(exception, packageId, camunda8DeployedProcess, bpmn);
+        return staleRecoverAddProcess(exception, workflowModuleId, packageId, camunda8DeployedProcess, bpmn);
 
     }
 
     private DeployedProcess staleRecoverAddProcess(
             final Exception exception,
+            final String workflowModuleId,
             final int packageId,
             final Process camunda8DeployedProcess,
             final DeployedBpmn bpmn) {
@@ -144,13 +153,17 @@ public class DeploymentService {
         throw new RuntimeException(
                 "Could not save Process '"
                         + camunda8DeployedProcess.getBpmnProcessId()
+                        + "' of workflow module '"
+                        + workflowModuleId
                         + "' in local DB due to stale OptimisticLockingFailureException", exception);
 
     }
 
-    public List<? extends DeployedBpmn> getBpmnNotOfPackage(final int packageId) {
+    public List<? extends DeployedBpmn> getBpmnNotOfPackage(
+            final String workflowModuleId,
+            final int packageId) {
 
-        return persistence.getBpmnNotOfPackage(packageId);
+        return persistence.getBpmnNotOfPackage(workflowModuleId, packageId);
 
     }
 

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/jpa/DeployedBpmnRepository.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/jpa/DeployedBpmnRepository.java
@@ -9,6 +9,6 @@ public interface DeployedBpmnRepository extends JpaRepository<DeployedBpmn, Inte
 
     String BEAN_NAME = "Camunda8DeployedBpmnRepository";
 
-    List<DeployedBpmn> findByDeployments_packageIdNot(int packageId);
+    List<DeployedBpmn> findByDeployments_workflowModuleIdAndDeployments_PackageIdNot(String workflowModuleId, int packageId);
 
 }

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/jpa/Deployment.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/jpa/Deployment.java
@@ -38,6 +38,9 @@ public abstract class Deployment
     @Column(name = "C8D_PACKAGE_ID")
     private int packageId;
 
+    @Column(name = "C8D_WORKFLOWMODULE_ID")
+    private String workflowModuleId;
+
     @ManyToOne(optional = false)
     @JoinColumn(name = "C8D_RESOURCE", nullable = false, updatable = false)
     private DeploymentResource deployedResource;
@@ -91,6 +94,14 @@ public abstract class Deployment
     
     public void setRecordVersion(int recordVersion) {
         this.recordVersion = recordVersion;
+    }
+
+    public String getWorkflowModuleId() {
+        return workflowModuleId;
+    }
+
+    public void setWorkflowModuleId(String workflowModuleId) {
+        this.workflowModuleId = workflowModuleId;
     }
 
     @Override

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/jpa/JpaDeploymentPersistence.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/jpa/JpaDeploymentPersistence.java
@@ -38,10 +38,23 @@ public class JpaDeploymentPersistence implements DeploymentPersistence {
 
     @Override
     @SuppressWarnings("unchecked")
+    public <R extends DeployedProcess> R updateMissingWorkflowModuleIdOfDeployedProcess(
+            final R deployedProcess,
+            final String workflowModuleId) {
+
+        final var jpaDeployedProcess = (io.vanillabp.camunda8.deployment.jpa.DeployedProcess) deployedProcess;
+        jpaDeployedProcess.setWorkflowModuleId(workflowModuleId);
+        return (R) deploymentRepository.save(jpaDeployedProcess);
+
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
     public <R extends DeployedProcess> R addDeployedProcess(
             final long definitionKey,
             final int version,
             final int packageId,
+            final String workflowModuleId,
             final String bpmnProcessId,
             final DeployedBpmn bpmn,
             final OffsetDateTime publishedAt) {
@@ -55,6 +68,7 @@ public class JpaDeploymentPersistence implements DeploymentPersistence {
         deployedProcess.setDefinitionKey(definitionKey);
         deployedProcess.setVersion(version);
         deployedProcess.setPackageId(packageId);
+        deployedProcess.setWorkflowModuleId(workflowModuleId);
         deployedProcess.setBpmnProcessId(bpmnProcessId);
         deployedProcess.setDeployedResource(bpmnEntity);
         deployedProcess.setPublishedAt(OffsetDateTime.now());
@@ -90,10 +104,11 @@ public class JpaDeploymentPersistence implements DeploymentPersistence {
 
     @Override
     public List<? extends DeployedBpmn> getBpmnNotOfPackage(
+            final String workflowModuleId,
             final int packageId) {
 
         return deployedBpmnRepository
-                .findByDeployments_packageIdNot(packageId)
+                .findByDeployments_workflowModuleIdAndDeployments_PackageIdNot(workflowModuleId, packageId)
                 .stream()
                 .distinct() // Oracle doesn't support distinct queries including blob columns, hence the job is done here
                 .toList();

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/mongodb/Deployment.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/mongodb/Deployment.java
@@ -29,6 +29,9 @@ public abstract class Deployment
     @Field(name = "C8D_PACKAGE_ID")
     private int packageId;
 
+    @Field(name = "C8D_WORKFLOWMODULE_ID")
+    private String workflowModuleId;
+
     @DocumentReference(
             collection = DeploymentResource.COLLECTION_NAME,
             lazy = true)
@@ -87,6 +90,15 @@ public abstract class Deployment
     
     public void setRecordVersion(int recordVersion) {
         this.recordVersion = recordVersion;
+    }
+
+    @Override
+    public String getWorkflowModuleId() {
+        return workflowModuleId;
+    }
+
+    public void setWorkflowModuleId(String workflowModuleId) {
+        this.workflowModuleId = workflowModuleId;
     }
 
     @Override

--- a/spring-boot/src/main/resources/io/vanillabp/camunda8/liquibase/add_wfm_id.yaml
+++ b/spring-boot/src/main/resources/io/vanillabp/camunda8/liquibase/add_wfm_id.yaml
@@ -1,0 +1,11 @@
+databaseChangeLog:
+  - changeSet:
+      id: add-workflow-module-id
+      author: stephanpelikan
+      changes:
+        - addColumn:
+            tableName: CAMUNDA8_DEPLOYMENTS
+            columns:
+              - column:
+                  name: C8D_WORKFLOWMODULE_ID
+                  type: varchar(255)

--- a/spring-boot/src/main/resources/io/vanillabp/camunda8/liquibase/main.yaml
+++ b/spring-boot/src/main/resources/io/vanillabp/camunda8/liquibase/main.yaml
@@ -5,3 +5,6 @@ databaseChangeLog:
   - include:
       relativeToChangelogFile: true
       file: issue_26.yaml # https://github.com/camunda-community-hub/vanillabp-camunda8-adapter/issues/26
+  - include:
+      relativeToChangelogFile: true
+      file: add_wfm_id.yaml


### PR DESCRIPTION
Old BPMNs were deploy-t also for non-matching workflow module because it was not stored to which they belong to.