### PR TITLE
Use Camunda Client 8.9.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <artifactId>camunda8-adapter</artifactId>
 
   <name>VanillaBP SPI adapter for Camunda 8.x</name>
-  <version>1.8.1-SNAPSHOT</version>
+  <version>1.9.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>

--- a/spring-boot/README.md
+++ b/spring-boot/README.md
@@ -42,7 +42,7 @@ Just add this dependency to your project, no additional dependencies from Camund
 ```
 
 > [!IMPORTANT]
-> The Camunda 8 Spring Boot Starter depends on Apache HTTPClient >= 5.6.1.  
+> Since Camunda 8.9, the Camunda Spring Boot Starter depends on Apache HTTPClient >= 5.6.1.  
 > If you use the Spring Boot Dependency Management, it will instead pin the version to 5.5.  
 > Possible workarounds:
 > 

--- a/spring-boot/README.md
+++ b/spring-boot/README.md
@@ -37,17 +37,34 @@ Just add this dependency to your project, no additional dependencies from Camund
 <dependency>
   <groupId>org.camunda.community.vanillabp</groupId>
   <artifactId>camunda8-spring-boot-adapter</artifactId>
-  <version>1.0.0</version>
+  <version>1.9.0</version>
 </dependency>
 ```
+
+> [!IMPORTANT]
+> The Camunda 8 Spring Boot Starter depends on Apache HTTPClient >= 5.6.1.  
+> If you use the Spring Boot Dependency Management, it will instead pin the version to 5.5.  
+> Possible workarounds:
+> 
+> * Set the config property `<httpclient5.version>5.6.1</httpclient5.version>`
+> * Bring in your own dependency
+>   ```xml
+>   <dependency>
+>       <groupId>org.apache.httpcomponents.client5</groupId>
+>       <artifactId>httpclient5</artifactId>
+>       <version>5.6.1</version>
+>   </dependency>
+>   ```
+> 
+> Make sure to verify correctness via `mvn dependency:tree -Dincludes=org.apache.httpcomponents.client5:httpclient5`
 
 If you want a certain version of Zeebe client then you have to replace the transitive dependencies like this:
 
 ```xml
-<dependency> <!-- community client 8.5.4 -->
+<dependency> <!-- community client 8.8.8 -->
   <groupId>io.camunda.spring</groupId>
-  <artifactId>spring-boot-starter-camunda</artifactId>
-  <version>8.5.4</version>
+  <artifactId>spring-boot-3-starter-camunda</artifactId>
+  <version>8.8.8</version>
 </dependency>
 <dependency>
   <groupId>org.camunda.community.vanillabp</groupId>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.camunda.community.vanillabp</groupId>
     <artifactId>camunda8-adapter</artifactId>
-    <version>1.8.1-SNAPSHOT</version>
+    <version>1.9.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>camunda8-spring-boot-adapter</artifactId>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>io.vanillabp</groupId>
       <artifactId>spring-boot-support</artifactId>
-      <version>1.3.0</version>
+      <version>1.3.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>

--- a/spring-boot/pom.xml
+++ b/spring-boot/pom.xml
@@ -44,8 +44,8 @@
     </dependency>
     <dependency>
       <groupId>io.camunda</groupId>
-      <artifactId>camunda-spring-boot-starter</artifactId>
-      <version>8.8.8</version>
+      <artifactId>camunda-spring-boot-3-starter</artifactId>
+      <version>8.9.11</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/Camunda8AdapterConfiguration.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/Camunda8AdapterConfiguration.java
@@ -6,6 +6,7 @@ import io.vanillabp.camunda8.deployment.Camunda8DeploymentAdapter;
 import io.vanillabp.camunda8.service.Camunda8ProcessService;
 import io.vanillabp.camunda8.service.Camunda8TransactionAspect;
 import io.vanillabp.camunda8.service.Camunda8TransactionProcessor;
+import io.vanillabp.camunda8.service.ClientCleanupService;
 import io.vanillabp.camunda8.wiring.Camunda8Connectable.Type;
 import io.vanillabp.camunda8.wiring.Camunda8TaskHandler;
 import io.vanillabp.camunda8.wiring.Camunda8TaskWiring;
@@ -235,4 +236,9 @@ public class Camunda8AdapterConfiguration extends AdapterConfigurationBase<Camun
 
     }
 
+    @Bean
+    public ClientCleanupService clientCleanupService(Camunda8DeploymentAdapter deploymentAdapter,
+                                                     Camunda8TaskWiring taskWiring) {
+        return new ClientCleanupService(springDataUtil, deploymentAdapter, taskWiring);
+    }
 }

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/Camunda8DeploymentAdapter.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/deployment/Camunda8DeploymentAdapter.java
@@ -381,5 +381,12 @@ public class Camunda8DeploymentAdapter extends ModuleAwareBpmnDeployment {
                 .forEach(connectable -> taskWiring.wireTask(workflowModuleId, processService[0], connectable));
     	
     }
-    
+
+    /**
+     * Only necessary for Spring Boot tests / @CamundaSpringProcessTest.
+     * After one test has completed, we need to reinitialize the deployment priority list.
+     */
+    public void doCleanup() {
+        initializeCrossCuttingProperties();
+    }
 }

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/service/ClientCleanupService.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/service/ClientCleanupService.java
@@ -1,0 +1,38 @@
+package io.vanillabp.camunda8.service;
+
+import io.camunda.client.event.CamundaClientClosingEvent;
+import io.vanillabp.camunda8.deployment.Camunda8DeploymentAdapter;
+import io.vanillabp.camunda8.wiring.Camunda8TaskWiring;
+import io.vanillabp.springboot.adapter.SpringDataUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+
+/**
+ * In Spring Boot tests, where application contexts are reused, we do not want to keep references to old
+ * Repositories / CamundaClients. These should be recreated when required.
+ */
+public class ClientCleanupService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ClientCleanupService.class);
+
+    private final SpringDataUtil springDataUtil;
+    private final Camunda8DeploymentAdapter deploymentAdapter;
+    private final Camunda8TaskWiring taskWiring;
+
+    public ClientCleanupService(SpringDataUtil springDataUtil,
+                                Camunda8DeploymentAdapter deploymentAdapter,
+                                Camunda8TaskWiring taskWiring) {
+        this.springDataUtil = springDataUtil;
+        this.deploymentAdapter = deploymentAdapter;
+        this.taskWiring = taskWiring;
+    }
+
+    @EventListener
+    public void onClientClosed(CamundaClientClosingEvent event) {
+        logger.debug("Camunda client closed, cleaning up: {}", event);
+        springDataUtil.doCleanup();
+        deploymentAdapter.doCleanup();
+        taskWiring.doCleanup();
+    }
+}

--- a/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/Camunda8TaskWiring.java
+++ b/spring-boot/src/main/java/io/vanillabp/camunda8/wiring/Camunda8TaskWiring.java
@@ -183,6 +183,11 @@ public class Camunda8TaskWiring extends TaskWiringBase<Camunda8Connectable, Camu
         
     }
 
+    public void doCleanup() {
+        taskHandlers.clear();
+        workers.clear();
+    }
+
     @SuppressWarnings("unchecked")
     public Stream<Camunda8Connectable> connectablesForType(
             final String workerModuleId,


### PR DESCRIPTION
This MR primarily updates the Camunda Client to 8.9.

It also introduces a cleanup mechanism when the Camunda Client is closed, useful for tests with `@CamundaSpringProcessTest`.